### PR TITLE
chore: split bom version ref to allow overriding

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ grpc = "1.57.2"
 hypertrace-framework = "0.1.58"
 hypertrace-grpcutils = "0.12.2"
 hypertrace-kafka = "0.3.2"
+hypertrace-bom = "+"
 
 junit = "5.10.0"
 mockito = "5.5.0"
@@ -39,7 +40,7 @@ hypertrace-documentstore = { module = "org.hypertrace.core.documentstore:documen
 hypertrace-eventstore = { module = "org.hypertrace.core.eventstore:event-store", version = "0.1.3" }
 hypertrace-kafka-bom = { module = "org.hypertrace.core.kafkastreams.framework:kafka-bom", version.ref = "hypertrace-kafka" }
 hypertrace-kafka-framework = { module = "org.hypertrace.core.kafkastreams.framework:kafka-streams-framework", version.ref = "hypertrace-kafka" }
-hypertrace-bom = { module = "org.hypertrace.bom:hypertrace-bom", version = "+" }
+hypertrace-bom = { module = "org.hypertrace.bom:hypertrace-bom", version.ref = "hypertrace-bom" }
 
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }


### PR DESCRIPTION
## Description
Splitting the version ref allows overriding bom version when importing catalog
