### PR TITLE
fix: update grpc utils, vulnerability tests, schedule cadence

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,7 +1,7 @@
 name: Build and Validate
 on:
   schedule:
-    - cron: 16 10 * * 3
+    - cron: 16 10 * * *
   push:
     branches:
       - main

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 protoc = "3.24.1"
 grpc = "1.57.2"
 hypertrace-framework = "0.1.58"
-hypertrace-grpcutils = "0.12.2"
+hypertrace-grpcutils = "0.12.5"
 hypertrace-kafka = "0.3.2"
 hypertrace-bom = "+"
 

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -23,4 +23,16 @@
     <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
     <cve>CVE-2020-21469</cve>
   </suppress>
+  <suppress until="2023-11-30Z">
+    <notes><![CDATA[
+  This vulnerability is disputed, with the argument that SSL configuration is the responsibility of the client rather
+  than the transport. The change in default is under consideration for the next major Netty release, revisit then.
+  Regardless, our client (which is what brings in this dependency) enables the concerned feature, hostname verification
+  Ref:
+  https://github.com/grpc/grpc-java/issues/10033
+  https://github.com/netty/netty/issues/8537#issuecomment-1527896917
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+    <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
+  </suppress>
 </suppressions>

--- a/test-consumer/build.gradle.kts
+++ b/test-consumer/build.gradle.kts
@@ -22,4 +22,13 @@ dependencies {
   api(libs.protobuf.javautil)
   api(libs.jackson.databind)
   api(libs.grpc.core)
+  api(libs.grpc.stub)
+  api(libs.grpc.protobuf)
+  api(libs.grpc.api)
+  api(libs.grpc.netty)
+  api(libs.slf4j2.api)
+  api(libs.log4j.slf4j2.impl)
+  api(libs.javax.annotation)
+  api(libs.rxjava3)
+  api(libs.uuidcreator)
 }


### PR DESCRIPTION
## Description
- Updated grpc utils to latest
- Since this manages all dependency versions, increase test cadence to daily
- Update test to verify certain dependencies that were missing
	- add suppression for one transitive introduced by grpc netty with explanation 