### PR TITLE
chore: update service-framework version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 protoc = "3.24.1"
 grpc = "1.60.0"
-hypertrace-framework = "0.1.70"
+hypertrace-framework = "0.1.71"
 hypertrace-grpcutils = "0.13.1"
 hypertrace-kafka = "0.4.7"
 hypertrace-bom = "+"


### PR DESCRIPTION
update service-framework version to expose grpc latency histogram metrics