### PR TITLE
chore: upgrade gson

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ mockito = "5.8.0"
 [libraries]
 guava = { module = "com.google.guava:guava", version = "32.1.2-jre" }
 rholder-guava-retrying = { module = "com.github.rholder:guava-retrying", version = "2.0.0" }
+gson = { module = "com.google.code.gson:gson", version = "2.13.1" }
 guice = { module = "com.google.inject:guice", version = "6.0.0" }
 guice7 = { module = "com.google.inject:guice", version = "7.0.0" }
 google-re2j = { module = "com.google.re2j:re2j", version = "1.7" }

--- a/hypertrace-bom/build.gradle.kts
+++ b/hypertrace-bom/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     api(libs.hypertrace.configservice.spanprocessing.api)
 
     api(libs.guava)
+    api(libs.gson)
     api(libs.google.re2j)
     api(libs.guice)
     api(libs.rholder.guava.retrying)

--- a/test-consumer/build.gradle.kts
+++ b/test-consumer/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
   api(libs.guava)
   api(libs.rholder.guava.retrying)
+  api(libs.gson)
   api(libs.google.re2j)
   api(libs.guice7)
   api(libs.typesafe.config)


### PR DESCRIPTION
gson isn't actually vulnerable, but it's easier to just upgrade it than deal with the FP.