### PR TITLE
Revert "chore: use privileged token for approval"

### DIFF
--- a/.github/workflows/upgrade-version.yml
+++ b/.github/workflows/upgrade-version.yml
@@ -67,5 +67,5 @@ jobs:
       - name: Auto Approve Pull Request
         uses: hmarr/auto-approve-action@v4
         with:
-          github-token: ${{ steps.generate-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}


### PR DESCRIPTION
Reverts hypertrace/hypertrace-bom#72

This approach didn't work since it's considered a self approval. the original issue was that there's no way to add a bypass for the github actions bot, so instead I just removed the codeowner review requirement.