### PR TITLE
Update jackson-bom version to 2.21.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ grpc-netty = { module = "io.grpc:grpc-netty" }
 grpc-context = { module = "io.grpc:grpc-context" }
 grpc-inprocess = { module = "io.grpc:grpc-inprocess" }
 grpc-services = { module = "io.grpc:grpc-services" }
-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version = "2.21.1" }
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version = "2.21.4" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" }
 jackson-datatype-jdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" }


### PR DESCRIPTION
## Summary

Bumps `jackson-bom` from **2.21.1** → **2.21.4** in `gradle/libs.versions.toml`.

This is a patch-level upgrade within the 2.21.x series that pulls in security fixes for `jackson-databind`, with no API or behavioral changes.

## Why

- **CVE-2026-54513** ([GHSA-rmj7-2vxq-3g9f](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f)) — CVSS 8.1 (High)
  - `BasicPolymorphicTypeValidator.allowIfSubTypeIsArray()` permits array types without checking the component type, enabling instantiation of non-allowlisted classes via an array wrapper.
  - Affects `jackson-databind` `>= 2.19.0, < 2.21.4`. Fixed in 2.21.4.
- **CVE-2026-54512** ([GHSA-j3rv-43j4-c7qm](https://github.com/advisories/GHSA-j3rv-43j4-c7qm)) — CVSS 8.1 (High)
  - PTV bypass via generic type parameters in type IDs. Same affected range, same fix.

Both are weaknesses in `BasicPolymorphicTypeValidator` (CWE-184 / CWE-502).

## Verification

- Dependency version verified against published security advisories and Maven Central (`jackson-bom-2.21.4.pom` confirmed pinning `jackson-databind 2.21.4`).
- Patch-level upgrade within the same `2.21.x` series — no breaking changes expected.

## Test plan

- [ ] CI build succeeds
- [ ] Downstream consumers can resolve `jackson-databind` at 2.21.4 transitively via this BOM